### PR TITLE
fixes #951

### DIFF
--- a/docs/topics/vertx-community-and-product-versions.adoc
+++ b/docs/topics/vertx-community-and-product-versions.adoc
@@ -1,15 +1,14 @@
 [[vertx-community-and-product-versions]]
 = Community and Product Versions of {Vertx}
 
-.Community {Vertx} Version
-// link TBD
-Some of the {Vertx} components included in this release are not fully tested to run on OpenShift, and are provided as a xref:vertx-tech-preview-components[limited-supportability Technology Preview].
-These components are based on the community version `3.4.2` of {Vertx}.
+.Supported {Vertx} Version
 
-.Certified {Vertx} Version
+{Vertx} components version `3.4.2.redhat-006` are supported and provided as part of a Red Hat subscription.
+Supported {Vertx} runtime artifacts are available in the link:https://maven.repository.redhat.com/ga/[Red Hat Middleware JBoss General Availability Maven Repository^].
 
-The productized {Vertx} version `3.4.2.redhat-006` is certified to run on OpenShift and provided as part of the Red Hat subscription.
-The certified {Vertx} runtime artifacts are available from the link:https://maven.repository.redhat.com/ga/[Red Hat Middleware JBoss General Availability Maven Repository^].
+.Technology Preview {Vertx} Components
+
+Technology Preview {Vertx} components included with {ProductShortName} are subject to the xref:vertx-tech-preview-components[Technology Preview Features Support Scope^] and are not supported.
 
 //RN link TBD
-For a complete list of {Vertx} components provided as part of this release, see the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_application_runtimes/1/html-single/red_hat_openshift_application_runtimes_release_notes/#rn-runtime-components-vertx[Release Notes^].
+For a complete list of supported and Technology Preview {Vertx} components available with this release of {ProductShortName}, see the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_application_runtimes/1/html-single/red_hat_openshift_application_runtimes_release_notes/#rn-runtime-components-vertx[Release Notes^].

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -20,7 +20,8 @@ include::topics/vertx-key-concepts.adoc[leveloffset=+2]
 
 include::topics/vertx-community-and-product-versions.adoc[leveloffset=+2]
 
-include::topics/vertx-tech-preview-components.adoc[leveloffset=+2]
+// duplicates the release notes
+// include::topics/vertx-tech-preview-components.adoc[leveloffset=+2]
 
 include::topics/configuring-vertx.adoc[leveloffset=+2]
 


### PR DESCRIPTION
@Ladicek I removed the redundant tech preview table form the Vert.x guide.
I also changed the wording from "certified" to "supported" for supported Vertx components (There is also a separate statement about tech preview not being supported, so we are not mixing anything up:)) WDYT?